### PR TITLE
Fix VnGetUBR

### DIFF
--- a/valinet/utility/osversion.h
+++ b/valinet/utility/osversion.h
@@ -32,7 +32,7 @@ inline BOOL VnGetOSVersion(PRTL_OSVERSIONINFOW lpRovi)
 }
 
 // https://stackoverflow.com/questions/47926094/detecting-windows-10-os-build-minor-version
-inline DWORD32 VnGetUBR()
+inline DWORD32 VnGetUBR(void)
 {
     DWORD32 ubr = 0, ubr_size = sizeof(DWORD32);
     HKEY hKey;
@@ -63,6 +63,7 @@ inline DWORD32 VnGetUBR()
             &ubr_size
         );
     }
+    return ubr;
 }
 
 inline DWORD32 VnGetOSVersionAndUBR(PRTL_OSVERSIONINFOW lpRovi)


### PR DESCRIPTION
The value this function exists to retrieve wasn't being returned. This broke the new fix in Explorer Patcher for me.